### PR TITLE
Update for 4.0.0-snake-island-alpha-017

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.0.0-snake-island-alpha-016",
+      "version": "4.0.0-snake-island-alpha-017",
       "commands": [
         "fable"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.0.0-snake-island-alpha-011",
+      "version": "4.0.0-snake-island-alpha-016",
       "commands": [
         "fable"
       ]

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,7 @@
 dotnet tool restore
+
+# Build once and install the Python packages
+dotnet fable --lang py
+pip install -r fable_modules/requirements.txt
+
 dotnet fable watch --lang py --runWatch program.py "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,2 @@
 dotnet tool restore
-
-# Build once and install the Python packages
-dotnet fable --lang py
-pip install -r fable_modules/requirements.txt
-
 dotnet fable watch --lang py --runWatch program.py "$@"

--- a/program.fsx
+++ b/program.fsx
@@ -23,7 +23,7 @@ let main argv =
     printfn $"Hello {name}!"
 
     // Open file with builtin `open`
-    use file = builtins.``open``(StringPath "data.txt")
+    use file = builtins.``open``("data.txt", "r")
     file.read() |> printfn "File contents: %s"
 
     // Open file with Pandas. We don't have bindings yet


### PR DESCRIPTION
@alfonsogarciacaro I forgot when I closed my previous PR that you still need the fixes for the simplified open-call. Here's a PR that fixes it.

If you look at the Python code you will btw see that there's no `fable_modules` in the imports anymore. This makes things a bit more flexible since you might in fact delete `fable_library` from `fable_modules`, then pip-install it instead and the program will still work. Currently testing to see if this is a better solution ...